### PR TITLE
Remove dead units from diff array after server update (Issue #5)

### DIFF
--- a/functions/functions_general.js
+++ b/functions/functions_general.js
@@ -51,8 +51,7 @@ module.exports = {
         //serverarraydiff = [];
 
         delarray = serverarray.filter(el => el.deleted);
-        console.log("Server:" + servername + " Object count deleted before clearing: ");
-        console.log(delarray.length);
+        console.log(`Server:${servername} Object count deleted before clearing: ${delarray.length}`);
 
         // Delete the objects with the property deleted
         serverarray.splice(0, serverarray.length, ...serverarray.filter(el => !el.deleted));

--- a/main.js
+++ b/main.js
@@ -82,7 +82,19 @@ servers.forEach((dcsserver, index) => {
         console.log('connection start' + ",source " + conn.remoteAddress + ":" + conn.remotePort + ",URL " + conn.url);
         let timer = {"value": 0}; // Start at zero
         let serverupdate;
-        serverupdate = setInterval(() => { servers[index].serverarray = general_functions.GetArray(servers[index].serverarray, servers[index].serverarraydiff, sendglobal, timer, delay, conn, dcsserver.servername) }, delay);
+        serverupdate = setInterval(() => {
+          const a = servers[index].serverarray.length;
+          const b = servers[index].serverarraydiff.length;
+          const diff = b - a;
+          const dead = servers[index].serverarraydiff.filter(el => el.deleted).length;
+          console.log(`Add ${diff} new unit(s): ${a} -> ${b}`);
+
+          servers[index].serverarray = general_functions.GetArray(servers[index].serverarray, servers[index].serverarraydiff, sendglobal, timer, delay, conn, dcsserver.servername);
+          servers[index].serverarraydiff.splice(0, servers[index].serverarraydiff.length, ...servers[index].serverarraydiff.filter(el => !el.deleted));
+
+          const c = servers[index].serverarraydiff.length;
+          console.log(`Remove ${dead} dead unit(s): ${b} -> ${c}`);
+        }, delay);
         conn.on('close', function() {
           console.log('connection close ' + conn.remoteAddress + ":" + conn.remotePort );
         });


### PR DESCRIPTION
Removes any dead units from `serverarraydiff` _after_ being applied to the server array (for use in removing map pins) to alleviate infinite array growth. Also enhances the logging commands to provide more meaningful info.